### PR TITLE
feat: core engine — TokenTracker, ModelPricing, BudgetCircuitBreaker

### DIFF
--- a/budget-breaker/src/main/kotlin/dev/unityinflow/budget/BudgetCircuitBreaker.kt
+++ b/budget-breaker/src/main/kotlin/dev/unityinflow/budget/BudgetCircuitBreaker.kt
@@ -1,0 +1,55 @@
+package dev.unityinflow.budget
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Coroutine-aware circuit breaker for AI agent token budgets.
+ *
+ * Wraps agent code in a budget-tracked scope. Soft limit triggers callback + Flow event.
+ * Hard limit cancels the coroutine scope.
+ */
+class BudgetCircuitBreaker(
+    private val defaultBudget: AgentBudget = AgentBudget(),
+    private val pricing: ModelPricing = ModelPricing(),
+    private val onSoftLimit: ((BudgetReport) -> Unit)? = null,
+) {
+    private val reports = ConcurrentHashMap<String, BudgetReport>()
+    private val _events = MutableSharedFlow<BudgetEvent>(extraBufferCapacity = 64)
+
+    /** SharedFlow of budget events for reactive consumers. */
+    val events: SharedFlow<BudgetEvent> = _events.asSharedFlow()
+
+    /**
+     * Execute [block] within a budget-tracked scope.
+     * Use [BudgetScope.trackCall] inside the block to record token usage.
+     *
+     * @throws BudgetHardLimitException if hard limit is exceeded
+     */
+    suspend fun <T> withBudget(
+        agentId: String,
+        budget: AgentBudget = defaultBudget,
+        block: suspend BudgetScope.() -> T,
+    ): T {
+        val tracker = TokenTracker(agentId, budget)
+        val scope = BudgetScope(tracker, pricing, onSoftLimit, _events)
+        val startTime = System.currentTimeMillis()
+
+        return try {
+            coroutineScope {
+                scope.block()
+            }
+        } catch (e: BudgetHardLimitException) {
+            throw e
+        } finally {
+            val durationMs = System.currentTimeMillis() - startTime
+            reports[agentId] = scope.buildReport(durationMs)
+        }
+    }
+
+    /** Get the budget report for a completed agent run. */
+    fun getReport(agentId: String): BudgetReport? = reports[agentId]
+}

--- a/budget-breaker/src/main/kotlin/dev/unityinflow/budget/BudgetReport.kt
+++ b/budget-breaker/src/main/kotlin/dev/unityinflow/budget/BudgetReport.kt
@@ -1,0 +1,17 @@
+package dev.unityinflow.budget
+
+/**
+ * Summary of an agent's budget usage after a run completes.
+ */
+data class BudgetReport(
+    val agentId: String,
+    val model: String,
+    val promptTokens: Long,
+    val completionTokens: Long,
+    val totalTokens: Long,
+    val estimatedCostUsd: Double,
+    val softLimitBreachCount: Int,
+    val hardLimitBreached: Boolean,
+    val durationMs: Long,
+    val percentUsed: Double,
+)

--- a/budget-breaker/src/main/kotlin/dev/unityinflow/budget/BudgetScope.kt
+++ b/budget-breaker/src/main/kotlin/dev/unityinflow/budget/BudgetScope.kt
@@ -1,0 +1,87 @@
+package dev.unityinflow.budget
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * Scope DSL for tracking LLM calls within a budget.
+ * Call [trackCall] after each LLM invocation to record token usage.
+ */
+class BudgetScope internal constructor(
+    private val tracker: TokenTracker,
+    private val pricing: ModelPricing,
+    private val onSoftLimit: ((BudgetReport) -> Unit)?,
+    private val eventFlow: MutableSharedFlow<BudgetEvent>,
+) {
+    private val softLimitBreachCount = java.util.concurrent.atomic.AtomicInteger(0)
+    private val softLimitFired = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    /**
+     * Record token usage from an LLM call.
+     * Checks soft/hard limits after recording.
+     *
+     * @throws BudgetHardLimitException if hard limit is exceeded
+     */
+    suspend fun trackCall(promptTokens: Long, completionTokens: Long) {
+        tracker.add(promptTokens, completionTokens)
+
+        eventFlow.emit(
+            BudgetEvent.CallTracked(
+                agentId = tracker.agentId,
+                tokensUsed = tracker.totalTokens,
+                promptTokens = promptTokens,
+                completionTokens = completionTokens,
+            )
+        )
+
+        if (tracker.isAboveHardLimit()) {
+            val cost = pricing.estimateCost(
+                tracker.model, tracker.promptTokens, tracker.completionTokens
+            )
+            val event = BudgetEvent.HardLimitExceeded(
+                agentId = tracker.agentId,
+                tokensUsed = tracker.totalTokens,
+                budgetTokens = tracker.hardLimitTokens,
+                estimatedCostUsd = cost,
+            )
+            eventFlow.emit(event)
+            throw BudgetHardLimitException(
+                agentId = tracker.agentId,
+                tokensUsed = tracker.totalTokens,
+                budgetTokens = tracker.hardLimitTokens,
+                estimatedCostUsd = cost,
+            )
+        }
+
+        if (tracker.isAboveSoftLimit() && !softLimitFired.getAndSet(true)) {
+            softLimitBreachCount.incrementAndGet()
+            val report = buildReport(0)
+            onSoftLimit?.invoke(report)
+            eventFlow.emit(
+                BudgetEvent.SoftLimitReached(
+                    agentId = tracker.agentId,
+                    tokensUsed = tracker.totalTokens,
+                    budgetTokens = tracker.softLimitTokens,
+                    percentUsed = tracker.percentUsed(),
+                )
+            )
+        }
+    }
+
+    internal fun buildReport(durationMs: Long): BudgetReport {
+        val cost = pricing.estimateCost(
+            tracker.model, tracker.promptTokens, tracker.completionTokens
+        )
+        return BudgetReport(
+            agentId = tracker.agentId,
+            model = tracker.model,
+            promptTokens = tracker.promptTokens,
+            completionTokens = tracker.completionTokens,
+            totalTokens = tracker.totalTokens,
+            estimatedCostUsd = cost,
+            softLimitBreachCount = softLimitBreachCount.get(),
+            hardLimitBreached = tracker.isAboveHardLimit(),
+            durationMs = durationMs,
+            percentUsed = tracker.percentUsed(),
+        )
+    }
+}

--- a/budget-breaker/src/main/kotlin/dev/unityinflow/budget/ModelPricing.kt
+++ b/budget-breaker/src/main/kotlin/dev/unityinflow/budget/ModelPricing.kt
@@ -1,0 +1,43 @@
+package dev.unityinflow.budget
+
+/**
+ * Estimates LLM API costs based on token usage.
+ * Has hardcoded defaults for popular models, supports custom overrides.
+ */
+class ModelPricing(
+    private val overrides: Map<String, PriceConfig> = emptyMap(),
+) {
+    data class PriceConfig(
+        val inputPerMillion: Double,
+        val outputPerMillion: Double,
+    )
+
+    /** Estimate cost in USD for the given token usage. */
+    fun estimateCost(model: String, promptTokens: Long, completionTokens: Long): Double {
+        val config = overrides[model] ?: DEFAULTS[model] ?: return 0.0
+        val inputCost = (promptTokens.toDouble() / 1_000_000) * config.inputPerMillion
+        val outputCost = (completionTokens.toDouble() / 1_000_000) * config.outputPerMillion
+        return inputCost + outputCost
+    }
+
+    companion object {
+        private val DEFAULTS = mapOf(
+            // Claude (April 2026)
+            "claude-opus-4-6" to PriceConfig(15.0, 75.0),
+            "claude-sonnet-4-6" to PriceConfig(3.0, 15.0),
+            "claude-haiku-4-5" to PriceConfig(0.80, 4.0),
+            // OpenAI
+            "gpt-4o" to PriceConfig(2.50, 10.0),
+            "gpt-4o-mini" to PriceConfig(0.15, 0.60),
+            // Google
+            "gemini-2.5-pro" to PriceConfig(1.25, 10.0),
+            "gemini-2.5-flash" to PriceConfig(0.15, 0.60),
+            // Local (free)
+            "ollama" to PriceConfig(0.0, 0.0),
+        )
+
+        /** Convenience: estimate cost using default pricing (no overrides). */
+        fun estimateCost(model: String, promptTokens: Long, completionTokens: Long): Double =
+            ModelPricing().estimateCost(model, promptTokens, completionTokens)
+    }
+}

--- a/budget-breaker/src/main/kotlin/dev/unityinflow/budget/TokenTracker.kt
+++ b/budget-breaker/src/main/kotlin/dev/unityinflow/budget/TokenTracker.kt
@@ -1,0 +1,43 @@
+package dev.unityinflow.budget
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Thread-safe token counter with soft/hard limit checks.
+ * Uses AtomicLong for lock-free concurrent access.
+ */
+class TokenTracker(
+    val agentId: String,
+    private val budget: AgentBudget,
+) {
+    /** The model identifier from the budget configuration. */
+    val model: String get() = budget.model
+
+    /** The configured hard limit in tokens. */
+    val hardLimitTokens: Long get() = budget.hardLimitTokens
+
+    /** The configured soft limit in tokens. */
+    val softLimitTokens: Long get() = budget.softLimitTokens
+
+    private val _promptTokens = AtomicLong(0)
+    private val _completionTokens = AtomicLong(0)
+
+    val promptTokens: Long get() = _promptTokens.get()
+    val completionTokens: Long get() = _completionTokens.get()
+    val totalTokens: Long get() = _promptTokens.get() + _completionTokens.get()
+
+    /** Record token usage from an LLM call. */
+    fun add(promptTokens: Long, completionTokens: Long) {
+        _promptTokens.addAndGet(promptTokens)
+        _completionTokens.addAndGet(completionTokens)
+    }
+
+    /** Check if total tokens exceed the soft limit. */
+    fun isAboveSoftLimit(): Boolean = totalTokens >= budget.softLimitTokens
+
+    /** Check if total tokens exceed the hard limit. */
+    fun isAboveHardLimit(): Boolean = totalTokens >= budget.hardLimitTokens
+
+    /** Current usage as a percentage of the hard limit. */
+    fun percentUsed(): Double = (totalTokens.toDouble() / budget.hardLimitTokens) * 100.0
+}

--- a/budget-breaker/src/test/kotlin/dev/unityinflow/budget/BudgetCircuitBreakerTest.kt
+++ b/budget-breaker/src/test/kotlin/dev/unityinflow/budget/BudgetCircuitBreakerTest.kt
@@ -1,0 +1,148 @@
+package dev.unityinflow.budget
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class BudgetCircuitBreakerTest {
+
+    private val budget = AgentBudget(
+        model = "claude-sonnet-4-6",
+        hardLimitTokens = 1000,
+        softLimitTokens = 800,
+    )
+
+    @Test
+    fun `completes normally within budget`() = runTest {
+        val breaker = BudgetCircuitBreaker(budget)
+
+        val result = breaker.withBudget("agent-1") {
+            trackCall(promptTokens = 100, completionTokens = 50)
+            "done"
+        }
+
+        result shouldBe "done"
+    }
+
+    @Test
+    fun `throws on hard limit breach`() = runTest {
+        val breaker = BudgetCircuitBreaker(budget)
+
+        shouldThrow<BudgetHardLimitException> {
+            breaker.withBudget("agent-1") {
+                trackCall(promptTokens = 600, completionTokens = 500)
+            }
+        }
+    }
+
+    @Test
+    fun `fires callback on soft limit`() = runTest {
+        var callbackFired = false
+        val breaker = BudgetCircuitBreaker(
+            budget,
+            onSoftLimit = { callbackFired = true },
+        )
+
+        breaker.withBudget("agent-1") {
+            trackCall(promptTokens = 500, completionTokens = 350)
+        }
+
+        callbackFired shouldBe true
+    }
+
+    @Test
+    fun `emits event on soft limit`() = runTest {
+        val breaker = BudgetCircuitBreaker(budget)
+        val collected = mutableListOf<BudgetEvent>()
+
+        val eventJob = launch {
+            breaker.events.collect { collected.add(it) }
+        }
+
+        // Yield to let the collector subscribe before emitting
+        kotlinx.coroutines.yield()
+
+        breaker.withBudget("agent-1") {
+            trackCall(promptTokens = 500, completionTokens = 350)
+        }
+
+        // Yield to let collector process buffered events
+        kotlinx.coroutines.yield()
+        eventJob.cancel()
+
+        val softEvent = collected.filterIsInstance<BudgetEvent.SoftLimitReached>()
+        softEvent.size shouldBe 1
+        softEvent.first().agentId shouldBe "agent-1"
+    }
+
+    @Test
+    fun `generates report after completion`() = runTest {
+        val breaker = BudgetCircuitBreaker(budget)
+
+        breaker.withBudget("agent-1") {
+            trackCall(promptTokens = 200, completionTokens = 100)
+        }
+
+        val report = breaker.getReport("agent-1")
+        report shouldNotBe null
+        report?.totalTokens shouldBe 300
+        report?.hardLimitBreached shouldBe false
+    }
+
+    @Test
+    fun `generates report even after hard limit exception`() = runTest {
+        val breaker = BudgetCircuitBreaker(budget)
+
+        try {
+            breaker.withBudget("agent-1") {
+                trackCall(promptTokens = 600, completionTokens = 500)
+            }
+        } catch (_: BudgetHardLimitException) {
+            // expected
+        }
+
+        val report = breaker.getReport("agent-1")
+        report shouldNotBe null
+        report?.hardLimitBreached shouldBe true
+    }
+
+    @Test
+    fun `report includes cost estimation`() = runTest {
+        val breaker = BudgetCircuitBreaker(budget)
+
+        breaker.withBudget("agent-1") {
+            trackCall(promptTokens = 200, completionTokens = 100)
+        }
+
+        val report = breaker.getReport("agent-1")
+        report shouldNotBe null
+        report!!.estimatedCostUsd shouldBeGreaterThan 0.0 // safe: asserted non-null above
+    }
+
+    @Test
+    fun `supports multiple agents concurrently`() = runTest {
+        val breaker = BudgetCircuitBreaker(budget)
+
+        val job1 = launch {
+            breaker.withBudget("agent-1") {
+                trackCall(promptTokens = 100, completionTokens = 50)
+            }
+        }
+        val job2 = launch {
+            breaker.withBudget("agent-2") {
+                trackCall(promptTokens = 200, completionTokens = 100)
+            }
+        }
+
+        job1.join()
+        job2.join()
+
+        breaker.getReport("agent-1")?.totalTokens shouldBe 150
+        breaker.getReport("agent-2")?.totalTokens shouldBe 300
+    }
+}

--- a/budget-breaker/src/test/kotlin/dev/unityinflow/budget/BudgetCircuitBreakerTest.kt
+++ b/budget-breaker/src/test/kotlin/dev/unityinflow/budget/BudgetCircuitBreakerTest.kt
@@ -4,10 +4,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
 
 class BudgetCircuitBreakerTest {
 
@@ -42,17 +42,17 @@ class BudgetCircuitBreakerTest {
 
     @Test
     fun `fires callback on soft limit`() = runTest {
-        var callbackFired = false
+        val callbackFired = AtomicBoolean(false)
         val breaker = BudgetCircuitBreaker(
             budget,
-            onSoftLimit = { callbackFired = true },
+            onSoftLimit = { callbackFired.set(true) },
         )
 
         breaker.withBudget("agent-1") {
             trackCall(promptTokens = 500, completionTokens = 350)
         }
 
-        callbackFired shouldBe true
+        callbackFired.get() shouldBe true
     }
 
     @Test

--- a/budget-breaker/src/test/kotlin/dev/unityinflow/budget/BudgetReportTest.kt
+++ b/budget-breaker/src/test/kotlin/dev/unityinflow/budget/BudgetReportTest.kt
@@ -1,0 +1,47 @@
+package dev.unityinflow.budget
+
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class BudgetReportTest {
+
+    @Test
+    fun `creates report with all fields`() {
+        val report = BudgetReport(
+            agentId = "test-agent",
+            model = "claude-sonnet-4-6",
+            promptTokens = 500,
+            completionTokens = 200,
+            totalTokens = 700,
+            estimatedCostUsd = 0.0045,
+            softLimitBreachCount = 0,
+            hardLimitBreached = false,
+            durationMs = 1500,
+            percentUsed = 70.0,
+        )
+
+        report.agentId shouldBe "test-agent"
+        report.totalTokens shouldBe 700
+        report.estimatedCostUsd shouldBeGreaterThan 0.0
+        report.hardLimitBreached shouldBe false
+    }
+
+    @Test
+    fun `totalTokens equals prompt + completion`() {
+        val report = BudgetReport(
+            agentId = "test",
+            model = "claude-sonnet-4-6",
+            promptTokens = 300,
+            completionTokens = 200,
+            totalTokens = 500,
+            estimatedCostUsd = 0.0,
+            softLimitBreachCount = 0,
+            hardLimitBreached = false,
+            durationMs = 0,
+            percentUsed = 50.0,
+        )
+
+        report.totalTokens shouldBe (report.promptTokens + report.completionTokens)
+    }
+}

--- a/budget-breaker/src/test/kotlin/dev/unityinflow/budget/ModelPricingTest.kt
+++ b/budget-breaker/src/test/kotlin/dev/unityinflow/budget/ModelPricingTest.kt
@@ -1,0 +1,54 @@
+package dev.unityinflow.budget
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ModelPricingTest {
+
+    @Test
+    fun `estimates cost for Claude Sonnet`() {
+        val cost = ModelPricing.estimateCost("claude-sonnet-4-6", promptTokens = 1_000_000, completionTokens = 0)
+        cost shouldBe 3.0 // $3 per million input tokens
+    }
+
+    @Test
+    fun `estimates cost for Claude Opus output`() {
+        val cost = ModelPricing.estimateCost("claude-opus-4-6", promptTokens = 0, completionTokens = 1_000_000)
+        cost shouldBe 75.0 // $75 per million output tokens
+    }
+
+    @Test
+    fun `estimates combined input + output cost`() {
+        val cost = ModelPricing.estimateCost("claude-sonnet-4-6", promptTokens = 500_000, completionTokens = 100_000)
+        // 0.5M * $3/M + 0.1M * $15/M = $1.5 + $1.5 = $3.0
+        cost shouldBe 3.0
+    }
+
+    @Test
+    fun `returns zero for unknown model`() {
+        val cost = ModelPricing.estimateCost("unknown-model", promptTokens = 1000, completionTokens = 1000)
+        cost shouldBe 0.0
+    }
+
+    @Test
+    fun `supports custom price overrides`() {
+        val pricing = ModelPricing(
+            overrides = mapOf(
+                "my-model" to ModelPricing.PriceConfig(inputPerMillion = 10.0, outputPerMillion = 50.0)
+            )
+        )
+        val cost = pricing.estimateCost("my-model", promptTokens = 1_000_000, completionTokens = 0)
+        cost shouldBe 10.0
+    }
+
+    @Test
+    fun `override takes precedence over default`() {
+        val pricing = ModelPricing(
+            overrides = mapOf(
+                "claude-sonnet-4-6" to ModelPricing.PriceConfig(inputPerMillion = 99.0, outputPerMillion = 99.0)
+            )
+        )
+        val cost = pricing.estimateCost("claude-sonnet-4-6", promptTokens = 1_000_000, completionTokens = 0)
+        cost shouldBe 99.0
+    }
+}

--- a/budget-breaker/src/test/kotlin/dev/unityinflow/budget/TokenTrackerTest.kt
+++ b/budget-breaker/src/test/kotlin/dev/unityinflow/budget/TokenTrackerTest.kt
@@ -1,0 +1,87 @@
+package dev.unityinflow.budget
+
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class TokenTrackerTest {
+
+    private val budget = AgentBudget(
+        model = "claude-sonnet-4-6",
+        hardLimitTokens = 1000,
+        softLimitTokens = 800,
+    )
+
+    @Test
+    fun `tracks prompt and completion tokens separately`() {
+        val tracker = TokenTracker("test-agent", budget)
+        tracker.add(promptTokens = 100, completionTokens = 50)
+
+        tracker.promptTokens shouldBe 100
+        tracker.completionTokens shouldBe 50
+        tracker.totalTokens shouldBe 150
+    }
+
+    @Test
+    fun `accumulates tokens across multiple calls`() {
+        val tracker = TokenTracker("test-agent", budget)
+        tracker.add(promptTokens = 100, completionTokens = 50)
+        tracker.add(promptTokens = 200, completionTokens = 100)
+
+        tracker.totalTokens shouldBe 450
+    }
+
+    @Test
+    fun `detects soft limit breach`() {
+        val tracker = TokenTracker("test-agent", budget)
+        tracker.add(promptTokens = 500, completionTokens = 350)
+
+        tracker.isAboveSoftLimit() shouldBe true
+        tracker.isAboveHardLimit() shouldBe false
+    }
+
+    @Test
+    fun `detects hard limit breach`() {
+        val tracker = TokenTracker("test-agent", budget)
+        tracker.add(promptTokens = 600, completionTokens = 500)
+
+        tracker.isAboveHardLimit() shouldBe true
+    }
+
+    @Test
+    fun `reports percent used`() {
+        val tracker = TokenTracker("test-agent", budget)
+        tracker.add(promptTokens = 250, completionTokens = 250)
+
+        tracker.percentUsed() shouldBe 50.0
+    }
+
+    @Test
+    fun `is thread-safe under concurrent access`() = runTest {
+        val tracker = TokenTracker("test-agent", AgentBudget(hardLimitTokens = 1_000_000, softLimitTokens = 800_000))
+
+        val jobs = (1..100).map {
+            launch {
+                repeat(100) {
+                    tracker.add(promptTokens = 1, completionTokens = 1)
+                }
+            }
+        }
+        jobs.forEach { it.join() }
+
+        tracker.totalTokens shouldBe 20_000
+    }
+
+    @Test
+    fun `starts at zero`() {
+        val tracker = TokenTracker("test-agent", budget)
+
+        tracker.promptTokens shouldBe 0
+        tracker.completionTokens shouldBe 0
+        tracker.totalTokens shouldBe 0
+        tracker.isAboveSoftLimit() shouldBe false
+        tracker.isAboveHardLimit() shouldBe false
+    }
+}


### PR DESCRIPTION
## Summary

PR 2 of budget-breaker v0.0.1 Phase 1.

- **TokenTracker**: AtomicLong pair (prompt + completion), thread-safe, limit checks. Exposes `model`, `hardLimitTokens`, `softLimitTokens` from budget config.
- **ModelPricing**: Hardcoded defaults for Claude/GPT/Gemini/Ollama + custom overrides via Map. Companion object convenience method.
- **BudgetReport**: Data class for post-run summary (tokens, cost, duration, breach counts).
- **BudgetScope**: `trackCall()` DSL with soft/hard limit checks. Uses `AtomicInteger` for breach count, `AtomicBoolean` for soft limit fired flag (no `var`).
- **BudgetCircuitBreaker**: Coroutine supervisor with `withBudget()` API. Callback + SharedFlow for soft limit events. ConcurrentHashMap for reports.

## Test plan

- [x] 7 TokenTracker tests: separate tracking, accumulation, soft/hard limit detection, percent used, thread safety, zero start
- [x] 6 ModelPricing tests: Claude Sonnet/Opus, combined cost, unknown model, custom overrides, override precedence
- [x] 2 BudgetReport tests: all fields, totalTokens consistency
- [x] 8 BudgetCircuitBreaker tests: normal completion, hard limit, soft limit callback, soft limit flow event, report generation, report after exception, cost estimation, concurrent agents
- [x] **23 total tests, 0 failures** — clean build from scratch

## Constraints verified

- No `var` anywhere — uses AtomicInteger, AtomicBoolean, AtomicLong
- No `!!` without justifying comment (one in test, explained)
- No `Thread.sleep` — pure coroutines
- All source in `budget-breaker/src/main/kotlin/dev/unityinflow/budget/`
- All tests in `budget-breaker/src/test/kotlin/dev/unityinflow/budget/`